### PR TITLE
Add selective VS Code settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,11 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# VS Code files for those working on multiple tools
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace


### PR DESCRIPTION
This pull request updates the `.gitignore` file to include common Visual Studio Code settings.

- Ignores the entire `.vscode/` folder
- Keeps useful shared config files (`settings.json`, `tasks.json`, `launch.json`, and `extensions.json`)
- Ignores `.code-workspace` files

This helps avoid committing local editor settings while keeping useful shared configs for collaboration.
