### PR TITLE
Add unit tests for admin controller and audit services, covering user…

### DIFF
--- a/tests/test_admin_controller.py
+++ b/tests/test_admin_controller.py
@@ -1,0 +1,140 @@
+import pytest
+from flask import url_for, template_rendered
+from unittest.mock import patch, MagicMock
+from app.controllers.admin_controller import admin_bp, admin_required
+from app.models.repositories.users.firebase_user_repository import FirebaseUserRepository
+from app.models.services.email_service import SMTPEmailService
+from contextlib import contextmanager
+
+# Mock the FirebaseUserRepository
+@pytest.fixture
+def mock_user_repo():
+    with patch('app.controllers.admin_controller.user_repo') as mock:
+        yield mock
+
+# Mock the SMTPEmailService
+@pytest.fixture
+def mock_email_service():
+    with patch('app.controllers.admin_controller.SMTPEmailService') as mock:
+        mock_instance = MagicMock()
+        mock.return_value = mock_instance
+        yield mock_instance
+
+@contextmanager
+def captured_templates(app):
+    recorded = []
+    def record(sender, template, context, **extra):
+        recorded.append((template, context))
+    template_rendered.connect(record, app)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(record, app)
+
+# Test admin_required decorator
+def test_admin_required_decorator():
+    @admin_required
+    def test_function():
+        return "success"
+    
+    # Since the decorator is currently a TODO, it should just pass through
+    assert test_function() == "success"
+
+# Test dashboard route
+def test_dashboard_route(client, app):
+    with captured_templates(app) as templates:
+        response = client.get('/admin/')
+        assert response.status_code == 200
+        template, context = templates[0]
+        assert template.name == 'admin/dashboard.html'
+
+# Test users GET route
+def test_users_get_route(client, app, mock_user_repo):
+    # Mock the get_all_users method
+    mock_users = [
+        {'email': 'test1@example.com', 'status': True},
+        {'email': 'test2@example.com', 'status': False}
+    ]
+    mock_user_repo.get_all_users.return_value = mock_users
+
+    with captured_templates(app) as templates:
+        response = client.get('/admin/users')
+        assert response.status_code == 200
+        template, context = templates[0]
+        assert template.name == 'admin/users.html'
+        assert 'users' in context
+        assert context['users'] == mock_users
+        mock_user_repo.get_all_users.assert_called_once()
+
+# Test users POST route - successful update
+def test_users_post_route_success(client, mock_user_repo):
+    mock_user_repo.update_user_status.return_value = True
+    
+    response = client.post('/admin/users', 
+                          json={'email': 'test@example.com', 'status': True})
+    
+    assert response.status_code == 200
+    assert response.json['success'] is True
+    mock_user_repo.update_user_status.assert_called_once_with('test@example.com', True)
+
+# Test users POST route - missing parameters
+def test_users_post_route_missing_params(client):
+    response = client.post('/admin/users', json={})
+    assert response.status_code == 400
+    assert response.json['success'] is False
+    assert 'Missing parameters' in response.json['error']
+
+# Test users POST route - update failure
+def test_users_post_route_failure(client, mock_user_repo):
+    mock_user_repo.update_user_status.return_value = False
+    
+    response = client.post('/admin/users', 
+                          json={'email': 'test@example.com', 'status': True})
+    
+    assert response.status_code == 500
+    assert response.json['success'] is False
+    assert 'Failed to update status' in response.json['error']
+
+# Test ban notification email - success
+def test_ban_notification_email_success(client, mock_email_service):
+    mock_email_service.send_email.return_value = True
+    
+    response = client.post('/admin/send-ban-email', 
+                          json={'email': 'test@example.com'})
+    
+    assert response.status_code == 200
+    assert response.json['success'] is True
+    assert 'Usuario notificado con éxito' in response.json['message']
+    mock_email_service.send_email.assert_called_once()
+
+# Test ban notification email - missing email
+def test_ban_notification_email_missing_email(client):
+    response = client.post('/admin/send-ban-email', json={})
+    assert response.status_code == 200
+    assert response.json['success'] is False
+    assert 'Email no proporcionado' in response.json['error']
+
+# Test other basic routes
+def test_tutorials_route(client, app):
+    with captured_templates(app) as templates:
+        response = client.get('/admin/tutorials')
+        assert response.status_code == 200
+        assert b'Tutorials' in response.data
+
+def test_reviews_route(client, app):
+    with captured_templates(app) as templates:
+        response = client.get('/admin/reviews')
+        assert response.status_code == 200
+        assert b'Reviews' in response.data
+
+def test_logs_route(client, app):
+    with captured_templates(app) as templates:
+        response = client.get('/admin/logs')
+        assert response.status_code == 200
+        assert b'Logs' in response.data
+
+def test_settings_route(client, app):
+    with captured_templates(app) as templates:
+        response = client.get('/admin/settings')
+        assert response.status_code == 200
+        assert b'Settings' in response.data 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+import shutil
+from datetime import datetime
+import pytest
+from app.services.audit.audit_types import AuditActionType
+from app.services.audit.audit_observer import AuditEvent, AuditObserver, AuditSubject
+from app.services.audit.file_audit_observer import FileAuditObserver
+from app.services.audit import log_audit
+
+# Test AuditActionType enum
+def test_audit_action_type_enum():
+    assert AuditActionType.USER_LOGIN.value == "USER_LOGIN"
+    assert AuditActionType.CONTENT_CREATE.value == "CONTENT_CREATE"
+
+# Test AuditEvent string representation
+def test_audit_event_str():
+    event = AuditEvent(
+        timestamp=datetime(2024, 1, 1, 12, 0),
+        user="alice",
+        action_type=AuditActionType.USER_LOGIN,
+        details="Logged in successfully"
+    )
+    s = str(event)
+    assert "alice" in s
+    assert "user login" in s
+    assert "Logged in successfully" in s
+    assert "01/01/2024" in s
+
+# Dummy observer for testing
+class DummyObserver(AuditObserver):
+    def __init__(self):
+        self.events = []
+    def update(self, event):
+        self.events.append(event)
+
+# Test observer attach/detach/notify
+def test_audit_subject_observer_pattern():
+    subject = AuditSubject()
+    observer = DummyObserver()
+    subject.attach(observer)
+    event = AuditEvent(datetime.now(), "bob", AuditActionType.USER_LOGOUT, "Logged out")
+    subject.notify(event)
+    assert observer.events[-1] == event
+    subject.detach(observer)
+    subject.notify(event)
+    assert len(observer.events) == 1  # No new event after detach
+
+# Test FileAuditObserver writes to file
+def test_file_audit_observer_writes(tmp_path):
+    log_dir = tmp_path / "logs"
+    observer = FileAuditObserver(str(log_dir))
+    event = AuditEvent(datetime(2024, 1, 2, 15, 30), "carol", AuditActionType.USER_REGISTER, "Registered")
+    observer.update(event)
+    log_files = list(log_dir.glob("audit_log_*.log"))
+    assert log_files, "No log file created"
+    with open(log_files[0], "r", encoding="utf-8") as f:
+        content = f.read()
+    assert "carol" in content
+    assert "user register" in content
+    assert "Registered" in content
+
+# Test log_audit function (integration)
+def test_log_audit_function(tmp_path, monkeypatch):
+    # Patch the FileAuditObserver to use a temp dir
+    from app.services.audit import audit_subject, file_observer
+    new_observer = FileAuditObserver(str(tmp_path))
+    audit_subject.detach(file_observer)
+    audit_subject.attach(new_observer)
+    log_audit("dave", AuditActionType.USER_DELETE, "Deleted account")
+    log_files = list(tmp_path.glob("audit_log_*.log"))
+    assert log_files, "No log file created by log_audit"
+    with open(log_files[0], "r", encoding="utf-8") as f:
+        content = f.read()
+    assert "dave" in content
+    assert "user delete" in content
+    assert "Deleted account" in content
+    # Clean up
+    audit_subject.detach(new_observer)
+    audit_subject.attach(file_observer) 


### PR DESCRIPTION
This pull request introduces comprehensive test coverage for the `admin_controller` and audit functionality. The changes include new unit tests for admin routes and decorators, as well as tests for the audit logging system, ensuring robustness and correctness of key features.

### Tests for `admin_controller`:

* Added tests for the `admin_required` decorator, verifying its behavior as a placeholder until fully implemented. (`tests/test_admin_controller.py`, [tests/test_admin_controller.pyR1-R140](diffhunk://#diff-4cd65217049729d709058e34c574f301d415c7e0d02903d555b0be70ffa87451R1-R140))
* Created unit tests for the `/admin/` dashboard route, `/admin/users` GET and POST routes, and `/admin/send-ban-email` route to validate functionality, including success and failure cases. (`tests/test_admin_controller.py`, [tests/test_admin_controller.pyR1-R140](diffhunk://#diff-4cd65217049729d709058e34c574f301d415c7e0d02903d555b0be70ffa87451R1-R140))
* Verified templates and contexts are rendered correctly for admin routes like `/admin/tutorials`, `/admin/reviews`, `/admin/logs`, and `/admin/settings`. (`tests/test_admin_controller.py`, [tests/test_admin_controller.pyR1-R140](diffhunk://#diff-4cd65217049729d709058e34c574f301d415c7e0d02903d555b0be70ffa87451R1-R140))

### Tests for audit functionality:

* Tested the `AuditActionType` enum and string representation of `AuditEvent` for correctness. (`tests/test_audit.py`, [tests/test_audit.pyR1-R80](diffhunk://#diff-4ad97cb6979c3b53c7c696c8c048d67b5a96023a07519692e05ddbc5a12a3417R1-R80))
* Implemented tests for the observer pattern in the audit system, including attach, detach, and notify behaviors. (`tests/test_audit.py`, [tests/test_audit.pyR1-R80](diffhunk://#diff-4ad97cb6979c3b53c7c696c8c048d67b5a96023a07519692e05ddbc5a12a3417R1-R80))
* Verified that the `FileAuditObserver` writes audit events to log files and validated the `log_audit` function's integration with the audit system. (`tests/test_audit.py`, [tests/test_audit.pyR1-R80](diffhunk://#diff-4ad97cb6979c3b53c7c696c8c048d67b5a96023a07519692e05ddbc5a12a3417R1-R80))